### PR TITLE
Report VM identity (if available) to the proxy.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -104,7 +104,7 @@ func pollForNewRequests(client *http.Client, backendID string) {
 		if requests, err := utils.ListPendingRequests(client, *proxy, backendID); err != nil {
 			log.Printf("Failed to read pending requests: %q\n", err.Error())
 			time.Sleep(exponentialBackoffDuration(retryCount))
-			retryCount += 1
+			retryCount++
 		} else {
 			retryCount = 0
 			for _, requestID := range requests {


### PR DESCRIPTION
This change adds a new header in the requests that the agent sends to the
proxy. That header is used to report the identity of the host VM for the
scenario that the agent is running inside of a Google Compute Engine VM.

When running outside of Google Compute Engine, this change is a no-op.

This change also cleaned up existing lint issues in the agent.