### PR TITLE
Set a timeout in the HTTP client used by the agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -221,6 +221,7 @@ func runAdapter() error {
 	if err != nil {
 		return err
 	}
+	client.Timeout = 60 * time.Second
 
 	hostProxy, err := hostProxy(ctx, *host, *shimPath, *shimWebsockets)
 	if err != nil {


### PR DESCRIPTION
This commit sets a timeout in the HTTP client used by the agent, addressing #4 .