### PR TITLE
Fix the package name for the `agent_test.go` file.

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package agent
+package main_test
 
 import (
 	"bufio"


### PR DESCRIPTION
The previous package name was `agent`, however, the package name in
the `agent.go` file is `main`. This mismatch causes issues if you try
to run `go build github.com/google/inverting-proxy/agent`.

With this updated version, the `go build ...` command will work.