### PR TITLE
agent: maintain ordering of the shimmed websocket messages

### DIFF
--- a/agent/websockets/shim.go
+++ b/agent/websockets/shim.go
@@ -122,6 +122,23 @@ const (
         }
       }
 
+      self.pendingMessages = [];
+      self.pushing = false;
+      self.push = function() {
+         if (self.pushing) {
+           return;
+         }
+         if (self.pendingMessages.length == 0) {
+           return;
+         }
+         self.pushing = true;
+         var msg = self.pendingMessages.shift();
+         self.xhr('data', msg, null, function() {
+           self.pushing = false;
+           self.push();
+         })
+      }
+
       function poll() {
         if (self.readyState != WebSocketShim.OPEN) {
           return;
@@ -147,7 +164,8 @@ const (
         if (this.readyState != WebSocketShim.OPEN) {
           throw new Error('WebSocket is not yet opened');
         }
-        this.xhr('data', {'id': this._sessionID, 'msg': data});
+        this.pendingMessages.push({'id': this._sessionID, 'msg': data});
+        self.push();
       },
       close: function() {
         if (this.readyState != WebSocketShim.OPEN) {


### PR DESCRIPTION
Data sent via websockets are supposed to be sent in-order, but the
previous version of the client-side code for the websocket shim sent
all messages asynchronously, which could cause them to be received
out of order by the agent.

This change adds an array for storing the websocket data to be sent,
and has the client-side JS code work through this array in sequence.

Thanks to @zainrizvi for finding this bug and tracking it down to the root cause.