### PR TITLE
Fix a bug in the locally-runnable proxy where headers were not copied

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/google/inverting-proxy/agent/utils"
 )
 
@@ -217,6 +218,9 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case resp := <-pending.respChan:
 		defer resp.Body.Close()
+		for key, vals := range resp.Header {
+			w.Header()[key] = vals
+		}
 		w.WriteHeader(resp.StatusCode)
 		io.Copy(w, resp.Body)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -194,7 +194,7 @@ func (p *proxy) newID() string {
 //
 // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hbh
 func isHopByHopHeader(name string) bool {
-	switch n := strings.ToLower(name); n {
+	switch strings.ToLower(name) {
 	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
 		return true
 	default:


### PR DESCRIPTION
This change fixes a bug in the locally-runnable version of the
inverting proxy where the headers from a proxied response were not
copied in to the response sent back to the frontend client.

That prevents things like set-cookie from working when testing local
changes.

That, in turn, was blocking the testing of a fix to
https://github.com/google/inverting-proxy/issues/31