### PR TITLE
Add flag to turn off adding GCE VM headers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -66,6 +66,7 @@ var (
 	healthCheckPath      = flag.String("health-check-path", "/", "Path on backend host to issue health checks against.  Defaults to the root.")
 	healthCheckFreq      = flag.Int("health-check-interval-seconds", 0, "Wait time in seconds between health checks.  Set to zero to disable health checks.  Checks disabled by default.")
 	healthCheckUnhealthy = flag.Int("health-check-unhealthy-threshold", 2, "A so-far healthy backend will be marked unhealthy after this many consecutive failures. The minimum value is 1.")
+        disableGCEVM         = flag.Bool("disable-gce-vm-header", false, "Disable the agent from adding a GCE VM header.")
 
 	sessionCookieName       = flag.String("session-cookie-name", "", "Name of the session cookie; an empty value disables agent-based session tracking")
 	sessionCookieTimeout    = flag.Duration("session-cookie-timeout", 12*time.Hour, "Expiration flag for the session cookie")
@@ -177,7 +178,7 @@ func getGoogleClient(ctx context.Context) (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	client.Transport = utils.RoundTripperWithVMIdentity(ctx, client.Transport, *proxy)
+	client.Transport = utils.RoundTripperWithVMIdentity(ctx, client.Transport, *proxy, *disableGCEVM)
 	return client, nil
 }
 

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -187,8 +187,8 @@ func (t *vmTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 // This method relies on the Google Compute Engine functionality for verifying a VM's identity
 // (https://cloud.google.com/compute/docs/instances/verifying-instance-identity), so it if this
 // is not running inside of a Google Compute Engine VM, then it just returns the passed in RoundTripper.
-func RoundTripperWithVMIdentity(ctx context.Context, wrapped http.RoundTripper, proxyURL string) http.RoundTripper {
-	if !hasVMServiceAccount() {
+func RoundTripperWithVMIdentity(ctx context.Context, wrapped http.RoundTripper, proxyURL string, disableGCEVM bool) http.RoundTripper {
+	if !hasVMServiceAccount() || disableGCEVM {
 		return wrapped
 	}
 


### PR DESCRIPTION
This functionality is currently broken for GKE deployments, so for now turn this off with a flag.