### PR TITLE
agent: add request headers to new websocket connections

### DIFF
--- a/agent/websockets/connection.go
+++ b/agent/websockets/connection.go
@@ -53,11 +53,9 @@ var stripHeaderNames = map[string]bool{
 // while preserving the rest.
 func stripWSHeader(header http.Header) http.Header {
 	result := http.Header{}
-	for k, vals := range header {
+	for k, v := range header {
 		if !stripHeaderNames[k] {
-			for _, v := range vals {
-				result.Add(k, v)
-			}
+			result[k] = v
 		}
 	}
 	return result

--- a/agent/websockets/connection.go
+++ b/agent/websockets/connection.go
@@ -18,7 +18,7 @@ package websockets
 
 import (
 	"fmt"
-	"log"
+	"net/http"
 	"sync"
 	"time"
 
@@ -38,12 +38,36 @@ type Connection struct {
 	serverMessages chan string
 }
 
+// This map defines the set of headers that should be stripped from the WS request, as they
+// are being verified by the websocket.Client.
+var stripHeaderNames = map[string]bool{
+	"Upgrade":                  true,
+	"Connection":               true,
+	"Sec-Websocket-Key":        true,
+	"Sec-Websocket-Version":    true,
+	"Sec-Websocket-Extensions": true,
+	"Sec-Websocket-Protocol":   true,
+}
+
+// stripWSHeader strips request headers that are not allowed by the websocket.Client library,
+// while preserving the rest.
+func stripWSHeader(header http.Header) http.Header {
+	result := http.Header{}
+	for k, vals := range header {
+		if !stripHeaderNames[k] {
+			for _, v := range vals {
+				result.Add(k, v)
+			}
+		}
+	}
+	return result
+}
+
 // NewConnection creates and returns a new Connection.
-func NewConnection(ctx context.Context, targetURL string, errCallback func(err error)) (*Connection, error) {
+func NewConnection(ctx context.Context, targetURL string, header http.Header, errCallback func(err error)) (*Connection, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	serverConn, _, err := websocket.DefaultDialer.Dial(targetURL, nil)
+	serverConn, _, err := websocket.DefaultDialer.Dial(targetURL, stripWSHeader(header))
 	if err != nil {
-		log.Printf("Failed to dial the websocket server %q: %v\n", targetURL, err)
 		cancel()
 		return nil, err
 	}

--- a/agent/websockets/shim.go
+++ b/agent/websockets/shim.go
@@ -256,17 +256,17 @@ func createShimChannel(ctx context.Context, host, shimPath string) http.Handler 
 		}
 		targetURL.Scheme = "ws"
 		targetURL.Host = host
-		conn, err := NewConnection(ctx, targetURL.String(),
+		conn, err := NewConnection(ctx, targetURL.String(), r.Header,
 			func(err error) {
 				log.Printf("Websocket failure: %v", err)
 			})
 		if err != nil {
-			log.Printf("Failed to dial the websocket server %q: %v\n", targetURL.String(), err)
+			log.Printf("Failed to dial the websocket server %q: %v\n", targetURL, err)
 			http.Error(w, fmt.Sprintf("internal error opening a shim connection: %v", err), http.StatusInternalServerError)
 			return
 		}
 		connections.Store(sessionID, conn)
-		log.Printf("Websocket connection to the server %q established for session: %v\n", targetURL.String(), sessionID)
+		log.Printf("Websocket connection to the server %q established for session: %v\n", targetURL, sessionID)
 		resp := &sessionMessage{
 			ID:      sessionID,
 			Message: targetURL.String(),


### PR DESCRIPTION
This change fixes a bug in the agent where request headers from websocket-shim open requests were not being copied into the websocket upgrade request forwarded to the backend server.

Fixes #43 