### PR TITLE
Add support for binary WebSocket messages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build:	test
 	go build ./app
 
-test:	buildrunlocal
+test:	buildrunlocal buildrunwebsockets
 	go test ./agent/banner/...
 	go test ./agent/sessions/...
 	go test ./agent/utils/...
@@ -9,6 +9,9 @@ test:	buildrunlocal
 
 buildrunlocal: buildagent buildserver
 	go build -o ${GOPATH}/bin/inverting-proxy-run-local ./testing/runlocal/main.go
+
+buildrunwebsockets: buildagent buildserver
+	go build -o ${GOPATH}/bin/inverting-proxy-run-websockets ./testing/websockets/main.go
 
 buildagent: vet
 	go build -o ${GOPATH}/bin/proxy-forwarding-agent ./agent/agent.go

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ buildrunlocal: buildagent buildserver
 
 buildrunwebsockets: buildagent buildserver
 	go build -o ${GOPATH}/bin/inverting-proxy-run-websockets ./testing/websockets/main.go
+	go build -o ${GOPATH}/bin/example-websocket-server ./testing/websockets/example/main.go
 
 buildagent: vet
 	go build -o ${GOPATH}/bin/proxy-forwarding-agent ./agent/agent.go

--- a/agent/websockets/connection.go
+++ b/agent/websockets/connection.go
@@ -23,8 +23,23 @@ import (
 	"time"
 
 	"context"
+
 	"github.com/gorilla/websocket"
 )
+
+type message struct {
+	Type int
+	Data []byte
+}
+
+func (m *message) Serialize() interface{} {
+	if m.Type == websocket.TextMessage {
+		return string(m.Data)
+	}
+	return []string{
+		string(m.Data),
+	}
+}
 
 // Connection implements a websocket client connection.
 //
@@ -34,8 +49,8 @@ import (
 type Connection struct {
 	ctx            context.Context
 	cancel         context.CancelFunc
-	clientMessages chan string
-	serverMessages chan string
+	clientMessages chan *message
+	serverMessages chan *message
 }
 
 // This map defines the set of headers that should be stripped from the WS request, as they
@@ -75,11 +90,11 @@ func NewConnection(ctx context.Context, targetURL string, header http.Header, er
 	//
 	// The most direct way to bridge those two approaches is to spawn a goroutine that reads in a
 	// tight loop, and then sends the read messages in to an open channel.
-	serverMessages := make(chan string, 10)
+	serverMessages := make(chan *message, 10)
 
 	// Since we are using a channel to pull messages from the connection, we will also use one to
 	// push messages. That way our handling of reads and writes are consistent.
-	clientMessages := make(chan string, 10)
+	clientMessages := make(chan *message, 10)
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -92,14 +107,17 @@ func NewConnection(ctx context.Context, targetURL string, header http.Header, er
 			case <-ctx.Done():
 				return
 			default:
-				_, msgBytes, err := serverConn.ReadMessage()
+				msgType, msgBytes, err := serverConn.ReadMessage()
 				if err != nil {
 					errCallback(fmt.Errorf("failed to read a websocket message from the server: %v", err))
 					// Errors from the server connection are terminal; once an error is returned
 					// no subsequent calls will succeed.
 					return
 				}
-				serverMessages <- string(msgBytes)
+				serverMessages <- &message{
+					Type: msgType,
+					Data: msgBytes,
+				}
 			}
 		}
 	}()
@@ -110,7 +128,10 @@ func NewConnection(ctx context.Context, targetURL string, header http.Header, er
 			case <-ctx.Done():
 				return
 			case clientMsg := <-clientMessages:
-				if err := serverConn.WriteMessage(websocket.TextMessage, []byte(clientMsg)); err != nil {
+				if clientMsg == nil {
+					continue
+				}
+				if err := serverConn.WriteMessage(clientMsg.Type, clientMsg.Data); err != nil {
 					errCallback(fmt.Errorf("failed to forward websocket data to the server: %v", err))
 					// Errors writing to the server connection are terminal; once an error is returned
 					// no subsequent calls will succeed.
@@ -147,12 +168,15 @@ func (conn *Connection) Close() {
 // SendClientMessage sends the given message to the websocket server.
 //
 // The returned error value is non-nill if the connection has been closed.
-func (conn *Connection) SendClientMessage(msg string) error {
+func (conn *Connection) SendClientMessage(messageType int, msg string) error {
 	select {
 	case <-conn.ctx.Done():
 		return fmt.Errorf("attempt to send a client message on a closed websocket connection")
 	default:
-		conn.clientMessages <- msg
+		conn.clientMessages <- &message{
+			Type: messageType,
+			Data: []byte(msg),
+		}
 	}
 	return nil
 }
@@ -163,20 +187,20 @@ func (conn *Connection) SendClientMessage(msg string) error {
 //
 // The returned []string value is nil if the error is non-nil, or if the method
 // times out while waiting for a server message.
-func (conn *Connection) ReadServerMessages() ([]string, error) {
-	var msgs []string
+func (conn *Connection) ReadServerMessages() ([]interface{}, error) {
+	var msgs []interface{}
 	select {
 	case serverMsg, ok := <-conn.serverMessages:
 		if !ok {
 			// The server messages channel has been closed.
 			return nil, fmt.Errorf("attempt to read a server message from a closed websocket connection")
 		}
-		msgs = append(msgs, serverMsg)
+		msgs = append(msgs, serverMsg.Serialize())
 		for {
 			select {
 			case serverMsg, ok := <-conn.serverMessages:
 				if ok {
-					msgs = append(msgs, serverMsg)
+					msgs = append(msgs, serverMsg.Serialize())
 				} else {
 					return msgs, nil
 				}

--- a/agent/websockets/shim.go
+++ b/agent/websockets/shim.go
@@ -33,6 +33,8 @@ import (
 	"text/template"
 
 	"context"
+
+	"github.com/gorilla/websocket"
 )
 
 const (
@@ -43,7 +45,7 @@ const (
     This file was served from behind a reverse proxy that does not support websockets.
 
     The following code snippet has been inserted by the proxy to replace websockets
-    with socket.io which is based on HTTP and will work with this proxy.
+    with HTTP requests that will work with this proxy.
 
     If this snippet insertion is causing issues, then contact the server administrator.
 -->
@@ -86,6 +88,9 @@ const (
         var msgs = JSON.parse(resp);
         if (self.onmessage) {
           msgs.forEach(function(msg) {
+            if (Array.isArray(msg)) {
+              msg = new Blob(msg);
+            }
             self.onmessage({ target: self, data: msg });
           });
         }
@@ -328,7 +333,7 @@ func createShimChannel(ctx context.Context, host, shimPath string) http.Handler 
 				http.Error(w, "internal error reading a shim session", http.StatusInternalServerError)
 				return
 			}
-			if err := conn.SendClientMessage(msg.Message); err != nil {
+			if err := conn.SendClientMessage(websocket.TextMessage, msg.Message); err != nil {
 				http.Error(w, fmt.Sprintf("attempt to send data on a closed session: %q", msg.ID), http.StatusBadRequest)
 				return
 			}

--- a/testing/websockets/example/main.go
+++ b/testing/websockets/example/main.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2019 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command example launches a server that can be used to exercise the
+// different websocket features. This, in turn, is used to test the
+// implementation of websockets provided by the inverting proxy and agent.
+//
+// Example usage:
+//   go build -o ~/bin/example-websocket-sever testing/websockets/example/main.go
+//   ~/bin/example-websocket-server --port 8082
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	subProtocol1 = "Sub-Protocol-1"
+	subProtocol2 = "Sub-Protocol-2"
+	subProtocol3 = "Sub-Protocol-3"
+	subProtocol4 = "Sub-Protocol-4"
+
+	html = `<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example websocket server</title>
+  </head>
+  <body>
+    <div id="log"/>
+    <script>
+    const logElement = document.getElementById("log");
+    function logEvent(msg, e) {
+        const entry = document.createElement("div");
+        entry.innerHTML = msg + " " + JSON.stringify(e);
+        logElement.appendChild(entry);
+    }
+
+    const conn = new WebSocket("ws://" + document.location.host + "/ws");
+    conn.onopen = function(e) {
+      logEvent("Connection opened [" + conn.protocol + "(" + conn.binaryType + ")]", e);
+    };
+    conn.onclose = function(e) {
+      logEvent("Connection closed", e);
+    };
+    conn.onmessage = function(e) {
+      var messageType = (typeof e.data);
+      logEvent("Message received [" + e.lastEventId + "(" + messageType + ")]", e);
+    };
+
+    function sendMessages(){
+      conn.send("Text Message");
+      conn.send(new Blob(["Binary Message"]));
+    }
+    window.setInterval(sendMessages, 10000);
+    </script>
+  </body>
+</html>
+`
+)
+
+var (
+	port = flag.Int("port", 0, "Port on which to listen")
+
+	upgrader = websocket.Upgrader{
+		Subprotocols: []string{
+			subProtocol1,
+			subProtocol2,
+			subProtocol3,
+			subProtocol4,
+		},
+	}
+)
+
+func homeServer(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(html))
+	return
+}
+
+type message struct {
+	Type int
+	Data []byte
+}
+
+func wsServer(w http.ResponseWriter, r *http.Request) {
+	if !websocket.IsWebSocketUpgrade(r) {
+		http.Error(w, fmt.Sprintf("Unsupported request: %+v", r), http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("Unexpected server error when upgrading: %+v\n", err)
+		http.Error(w, fmt.Sprintf("Unexpected server error: %v", err), http.StatusInternalServerError)
+		return
+	}
+	conn.SetCloseHandler(func(code int, text string) error {
+		cancel()
+		return nil
+	})
+	defer conn.Close()
+	msgChan := make(chan *message, 1024)
+	go func(ctx context.Context, conn *websocket.Conn, msgChan chan *message) {
+		for {
+			mt, mb, err := conn.ReadMessage()
+			if err != nil {
+				select {
+				case <-ctx.Done():
+				// The connection was closed, so this does not warrant logging...
+				default:
+					// The error is something else, so log it...
+					log.Printf("Error reading a message on a connection: %v\n", err)
+				}
+				// All errors on a connection are terminal
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case msgChan <- &message{Type: mt, Data: mb}:
+				continue
+			}
+		}
+	}(ctx, conn, msgChan)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case m := <-msgChan:
+			err := conn.WriteMessage(m.Type, m.Data)
+			if err != nil {
+				log.Printf("Error writing a message back on a connection: %v\n", err)
+				return
+			}
+		}
+	}
+}
+
+func main() {
+	flag.Parse()
+	if *port == 0 {
+		log.Fatal("You must specify a local port number on which to listen")
+	}
+	http.HandleFunc("/", homeServer)
+	http.HandleFunc("/ws", wsServer)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
+}


### PR DESCRIPTION
This PR extends the websocket-shim to support sending and receiving binary
messages over the shimmed WebSocket connections.

The WebSocket-over-HTTP protocol is extended such that messages
returned by the `poll` handler may be either a string (for text
messages), or an array of a single string (for binary messages). This is
intentionally backwards-compatible with the previous version of the
protocol, so any proxies implementing the shim layer in the proxy will
still work with the updated agent.

The shim code detects this difference between the possible types
and uses it to determine whether to emit an event with a string,
or an event with a Blob (which is constructed directly from the
array of the single string).

This was tested in two ways:

1. By running a proxy and agent with websocket shimming locally, pointing the agent
    at a locally running Jupyter notebook server, and then running the following snippet
    in a Jupyter notebook code cell:

```py
import ipywidgets

ipywidgets.Image(value='', format='png')
```

2. By creating a new, example server that exercises both text and binary websocket
    messages, and then accessing that server through a locally-running proxy.

Fixes #47