### PR TITLE
Make window url and history consistent when banner injection enabled

### DIFF
--- a/agent/banner/banner.go
+++ b/agent/banner/banner.go
@@ -45,7 +45,7 @@ const (
     <div height="{{.BannerHeight}}">
       {{.Banner}}
     </div>
-    <iframe width="100%" style="border:0px;height: calc(100% - {{.BannerHeight}})" src="{{.TargetURL}}"></iframe>
+    <iframe width="100%" id="inverting-proxy-frame" onLoad="window.history.replaceState(null, '', this.contentWindow.location)" style="border:0px;height: calc(100% - {{.BannerHeight}})" src="{{.TargetURL}}"></iframe>
   </body>
 </html>`
 )


### PR DESCRIPTION
This change makes sure that the browser displayed url and history are consistent with the iframe state.
Also adds an id field to the wrapper iframe to make Selenium testing easier