### PR TITLE
Fix bug in favicon url logic

### DIFF
--- a/agent/banner/banner.go
+++ b/agent/banner/banner.go
@@ -120,7 +120,7 @@ func setXFrameOptionsSameOrigin(h http.Header) {
 }
 
 func (w *bannerResponseWriter) getFavIconLink() (string, error) {
-	if w.favIconURL != "" {
+	if w.favIconURL == "" {
 		return "", nil
 	}
 	var favIconLinkBuf bytes.Buffer


### PR DESCRIPTION
Before this fix, the favicon logic was active when the flag was unset. This broke all requests with the banner enabled.