### PR TITLE
Unset Content-Encoding header when response contains banner HTML

### DIFF
--- a/agent/banner/banner.go
+++ b/agent/banner/banner.go
@@ -27,15 +27,16 @@ import (
 )
 
 const (
-	acceptHeader        = "Accept"
-	cacheControlHeader  = "Cache-Control"
-	contentTypeHeader   = "Content-Type"
-	dateHeader          = "Date"
-	expiresHeader       = "Expires"
-	refererHeader       = "Referer"
-	pragmaHeader        = "Pragma"
-	secFetchModeHeader  = "Sec-Fetch-Mode"
-	xFrameOptionsHeader = "X-Frame-Options"
+	acceptHeader          = "Accept"
+	cacheControlHeader    = "Cache-Control"
+	contentEncodingHeader = "Content-Encoding"
+	contentTypeHeader     = "Content-Type"
+	dateHeader            = "Date"
+	expiresHeader         = "Expires"
+	refererHeader         = "Referer"
+	pragmaHeader          = "Pragma"
+	secFetchModeHeader    = "Sec-Fetch-Mode"
+	xFrameOptionsHeader   = "X-Frame-Options"
 
 	frameWrapperTemplate = `<html>
   <head>
@@ -170,6 +171,8 @@ func (w *bannerResponseWriter) WriteHeader(statusCode int) {
 		w.wrapped.WriteHeader(statusCode)
 		w.writeBytes = true
 		return
+	} else {
+		w.Header().Del(contentEncodingHeader)
 	}
 	favIconLink, err := w.getFavIconLink()
 	if err != nil {


### PR DESCRIPTION
Fix a bug where trying to access a page that is compressed with e.g. gzip will fail if the banner is enabled. This occurs because on the initial request, we overwrite the page content with the banner HTML, but the content-encoding header is still 'gzip,' so the browser will fail to decode.