### PR TITLE
Improve detection of already framed pages

### DIFF
--- a/agent/banner/banner.go
+++ b/agent/banner/banner.go
@@ -35,6 +35,7 @@ const (
 	expiresHeader         = "Expires"
 	refererHeader         = "Referer"
 	pragmaHeader          = "Pragma"
+	secFetchDestHeader    = "Sec-Fetch-Dest"
 	secFetchModeHeader    = "Sec-Fetch-Mode"
 	xFrameOptionsHeader   = "X-Frame-Options"
 
@@ -79,7 +80,7 @@ func isHTMLResponse(statusCode int, responseHeader http.Header) bool {
 }
 
 func isAlreadyFramed(r *http.Request) bool {
-	if r.Header.Get(secFetchModeHeader) == "nested-navigate" {
+	if r.Header.Get(secFetchModeHeader) == "nested-navigate" || r.Header.Get(secFetchDestHeader) == "iframe" {
 		// If the browser told us the page is already framed, then believe it.
 		return true
 	}

--- a/agent/banner/banner_test.go
+++ b/agent/banner/banner_test.go
@@ -147,6 +147,8 @@ func TestIsAlreadyFramed(t *testing.T) {
 				},
 				Header: http.Header{
 					"Referer": []string{"https://example.com/some/other/path"},
+					"Sec-Fetch-Dest": []string{"document"},
+					"Sec-Fetch-Mode": []string{"navigate"},
 				},
 			},
 			want: false,
@@ -159,6 +161,32 @@ func TestIsAlreadyFramed(t *testing.T) {
 				},
 				Header: http.Header{
 					"Referer": []string{"https://example.com/some/example/path"},
+				},
+			},
+			want: true,
+		},
+		{
+			req: &http.Request{
+				Host: "example.com",
+				URL: &url.URL{
+					Path: "/some/example/path",
+				},
+				Header: http.Header{
+					"Referer": []string{"https://example.com/some/other/path"},
+					"Sec-Fetch-Dest": []string{"iframe"},
+				},
+			},
+			want: true,
+		},
+		{
+			req: &http.Request{
+				Host: "example.com",
+				URL: &url.URL{
+					Path: "/some/example/path",
+				},
+				Header: http.Header{
+					"Referer": []string{"https://example.com/some/other/path"},
+					"Sec-Fetch-Mode": []string{"nested-navigate"},
 				},
 			},
 			want: true,


### PR DESCRIPTION
As of Chrome 80, requests from iframes appear to arrive with Sec-Fetch-Mode: 'navigate' and Sec-Fetch-Dest: 'iframe', instead of the previous behavior of Sec-Fetch-Mode: 'nested-navigate' and Sec-Fetch-Dest: 'document.'

Adding this check allows to correctly handle either behavior.