### PR TITLE
Rewrite host header to original request host when opening a websocket connection

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -75,6 +75,7 @@ var (
 	sessionCookieName       = flag.String("session-cookie-name", "", "Name of the session cookie; an empty value disables agent-based session tracking")
 	sessionCookieTimeout    = flag.Duration("session-cookie-timeout", 12*time.Hour, "Expiration flag for the session cookie")
 	sessionCookieCacheLimit = flag.Int("session-cookie-cache-limit", 1000, "Upper bound on the number of concurrent sessions that can be tracked by the agent")
+	rewriteWebsocketHost = flag.Bool("rewrite-websocket-host", false, "Whether to rewrite the Host header to the original request when shimming a websocket connection")
 
 	sessionLRU *sessions.Cache
 )
@@ -88,7 +89,7 @@ func hostProxy(ctx context.Context, host, shimPath string, injectShimCode bool) 
 	var h http.Handler = hostProxy
 	if shimPath != "" {
 		var err error
-		h, err = websockets.Proxy(ctx, hostProxy, host, shimPath, injectShimCode)
+		h, err = websockets.Proxy(ctx, hostProxy, host, shimPath, injectShimCode, *rewriteWebsocketHost)
 		if err != nil {
 			return nil, err
 		}

--- a/testing/websockets/main.go
+++ b/testing/websockets/main.go
@@ -54,7 +54,7 @@ func main() {
 		log.Fatalf("Failure parsing the address of the backend server: %v", err)
 	}
 	backendProxy := httputil.NewSingleHostReverseProxy(backendURL)
-	shimmingProxy, err := websockets.Proxy(context.Background(), backendProxy, backendURL.Host, *shimPath, true)
+	shimmingProxy, err := websockets.Proxy(context.Background(), backendProxy, backendURL.Host, *shimPath, true, true)
 	if err != nil {
 		log.Fatal("Failure starting the websocket-shimming proxy: %v", err)
 	}


### PR DESCRIPTION
… connection

This change is gated behind the flag --rewrite-websocket-host