### PR TITLE
Swap order of websocket and session handlers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -75,7 +75,7 @@ var (
 	sessionCookieName       = flag.String("session-cookie-name", "", "Name of the session cookie; an empty value disables agent-based session tracking")
 	sessionCookieTimeout    = flag.Duration("session-cookie-timeout", 12*time.Hour, "Expiration flag for the session cookie")
 	sessionCookieCacheLimit = flag.Int("session-cookie-cache-limit", 1000, "Upper bound on the number of concurrent sessions that can be tracked by the agent")
-	rewriteWebsocketHost = flag.Bool("rewrite-websocket-host", false, "Whether to rewrite the Host header to the original request when shimming a websocket connection")
+	rewriteWebsocketHost    = flag.Bool("rewrite-websocket-host", false, "Whether to rewrite the Host header to the original request when shimming a websocket connection")
 
 	sessionLRU *sessions.Cache
 )
@@ -87,14 +87,19 @@ func hostProxy(ctx context.Context, host, shimPath string, injectShimCode bool) 
 	})
 	hostProxy.FlushInterval = 100 * time.Millisecond
 	var h http.Handler = hostProxy
+	h = sessionLRU.SessionHandler(h)
 	if shimPath != "" {
 		var err error
-		h, err = websockets.Proxy(ctx, hostProxy, host, shimPath, injectShimCode, *rewriteWebsocketHost)
+		h, err = websockets.Proxy(ctx, h, host, shimPath, *rewriteWebsocketHost, sessionLRU.SessionHandler)
+		if injectShimCode {
+			hostProxy.ModifyResponse = func(resp *http.Response) error {
+				return websockets.ShimBody(resp, shimPath)
+			}
+		}
 		if err != nil {
 			return nil, err
 		}
 	}
-	h = sessionLRU.SessionHandler(h)
 	if *injectBanner == "" {
 		return h, nil
 	}

--- a/testing/websockets/main.go
+++ b/testing/websockets/main.go
@@ -55,12 +55,14 @@ func main() {
 	}
 	backendProxy := httputil.NewSingleHostReverseProxy(backendURL)
 	shimmingProxy, err := websockets.Proxy(context.Background(), backendProxy, backendURL.Host, *shimPath, true, func(h http.Handler) http.Handler { return h })
-	backendProxy.ModifyResponse = func(resp *http.Response) error {
-		return websockets.ShimBody(resp, *shimPath)
-	}
 	if err != nil {
 		log.Fatal("Failure starting the websocket-shimming proxy: %v", err)
 	}
+	shimFunc, err := websockets.ShimBody(*shimPath)
+	if err != nil {
+		log.Fatal("Failure setting up shim injection code: %v", err)
+	}
+	backendProxy.ModifyResponse = shimFunc
 
 	http.Handle("/", shimmingProxy)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))

--- a/testing/websockets/main.go
+++ b/testing/websockets/main.go
@@ -54,7 +54,10 @@ func main() {
 		log.Fatalf("Failure parsing the address of the backend server: %v", err)
 	}
 	backendProxy := httputil.NewSingleHostReverseProxy(backendURL)
-	shimmingProxy, err := websockets.Proxy(context.Background(), backendProxy, backendURL.Host, *shimPath, true, true)
+	shimmingProxy, err := websockets.Proxy(context.Background(), backendProxy, backendURL.Host, *shimPath, true, func(h http.Handler) http.Handler { return h })
+	backendProxy.ModifyResponse = func(resp *http.Response) error {
+		return websockets.ShimBody(resp, *shimPath)
+	}
 	if err != nil {
 		log.Fatal("Failure starting the websocket-shimming proxy: %v", err)
 	}


### PR DESCRIPTION
This fixes an edge condition where cookies with path
restrictions are not sent when opening a websocket connection
because the path is `websocket-shim/open` when the session is restored.

This change brings the cookie handler downstream of the websocket
handler for non-shimmed requests, and restores cookies for
websocket open requests based on the correct path.