### PR TITLE
Adding standalone env variables for Dataproc Hub

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,11 +1,11 @@
 # Copyright 2017 Google Inc. All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,5 +50,8 @@ ENV SHIM_PATH ""
 ENV HEALTH_CHECK_PATH "/"
 ENV HEALTH_CHECK_INTERVAL_SECONDS "0"
 ENV HEALTH_CHECK_UNHEALTHY_THRESHOLD "2"
+ENV SESSION_COOKIE_NAME ""
+ENV FORWARD_USER_ID "false"
+ENV REWRITE_WEBSOCKET_HOST "false"
 
-CMD ["/bin/sh", "-c", "/opt/bin/proxy-forwarding-agent --debug=${DEBUG} --proxy=${PROXY} --proxy-timeout=${PROXY_TIMEOUT} --backend=${BACKEND} --host=${HOSTNAME}:${PORT} --shim-websockets=${SHIM_WEBSOCKETS} --shim-path=${SHIM_PATH} --health-check-path=${HEALTH_CHECK_PATH} --health-check-interval-seconds=${HEALTH_CHECK_INTERVAL_SECONDS} --health-check-unhealthy-threshold=${HEALTH_CHECK_UNHEALTHY_THRESHOLD}" ]
+CMD ["/bin/sh", "-c", "/opt/bin/proxy-forwarding-agent --debug=${DEBUG} --proxy=${PROXY} --proxy-timeout=${PROXY_TIMEOUT} --backend=${BACKEND} --host=${HOSTNAME}:${PORT} --shim-websockets=${SHIM_WEBSOCKETS} --shim-path=${SHIM_PATH} --health-check-path=${HEALTH_CHECK_PATH} --health-check-interval-seconds=${HEALTH_CHECK_INTERVAL_SECONDS} --health-check-unhealthy-threshold=${HEALTH_CHECK_UNHEALTHY_THRESHOLD} --session-cookie-name=${SESSION_COOKIE_NAME} --forward-user-id=${FORWARD_USER_ID} --rewrite-websocket-host=${REWRITE_WEBSOCKET_HOST}"]


### PR DESCRIPTION
- Variables required for Dataproc Hub. Default to "silent" values.
- Actual values sets through an env file.
- Those variables used to be passed through the string value of HEALTH_CHECK_UNHEALTHY_THRESHOLD.