### PR TITLE
Support passing an application subprotocol to the backend

### DIFF
--- a/agent/websockets/connection.go
+++ b/agent/websockets/connection.go
@@ -72,7 +72,6 @@ var stripHeaderNames = map[string]bool{
 	"Sec-Websocket-Key":        true,
 	"Sec-Websocket-Version":    true,
 	"Sec-Websocket-Extensions": true,
-	"Sec-Websocket-Protocol":   true,
 }
 
 // stripWSHeader strips request headers that are not allowed by the websocket.Client library,


### PR DESCRIPTION
Stop stripping the `Sec-WebSocket-Protocol` header from websocket upgrade requests to support application-level websocket subprotocols.