### PR TITLE
Fix golint errors

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -236,7 +236,7 @@ func waitForHealthy() {
 		return
 	}
 	ticker := time.NewTicker(time.Duration(*healthCheckFreq) * time.Second)
-	for _ = range ticker.C {
+	for range ticker.C {
 		if healthCheck() == nil {
 			ticker.Stop()
 			return
@@ -258,7 +258,7 @@ func runHealthChecks() {
 	// immediately.
 	ticker := time.NewTicker(time.Duration(*healthCheckFreq) * time.Second)
 	badHealthChecks := 0
-	for _ = range ticker.C {
+	for range ticker.C {
 		if healthCheck() != nil {
 			badHealthChecks++
 		} else {

--- a/agent/banner/banner.go
+++ b/agent/banner/banner.go
@@ -140,9 +140,9 @@ func (w *bannerResponseWriter) getFavIconLink() (string, error) {
 	}
 	var favIconLinkBuf bytes.Buffer
 	templateVals := &struct {
-		FavIconUrl string
+		FavIconURL string
 	}{
-		FavIconUrl: w.favIconURL,
+		FavIconURL: w.favIconURL,
 	}
 	if err := favIconLinkTmpl.Execute(&favIconLinkBuf, templateVals); err != nil {
 		return "", err
@@ -185,9 +185,9 @@ func (w *bannerResponseWriter) WriteHeader(statusCode int) {
 		w.wrapped.WriteHeader(statusCode)
 		w.writeBytes = true
 		return
-	} else {
-		w.Header().Del(contentEncodingHeader)
 	}
+	w.Header().Del(contentEncodingHeader)
+
 	favIconLink, err := w.getFavIconLink()
 	if err != nil {
 		sc := http.StatusInternalServerError

--- a/agent/metrics/metrics.go
+++ b/agent/metrics/metrics.go
@@ -48,6 +48,7 @@ type metricClient interface {
 	CreateTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest, opts ...gax.CallOption) error
 }
 
+// MetricHandler handles metrics collections/writes to cloud monarch
 type MetricHandler struct {
 	mu             sync.Mutex
 	projectID      string
@@ -147,7 +148,7 @@ func parseGCEResourceLabels(resourceKeyValues string) (*map[string]string, error
 		"zone":        "",
 	}
 	err := parseResourceLabels(resourceKeyValues, &flags)
-	for key, _ := range res {
+	for key := range res {
 		flagKey := responseCountResourceKeyToFlagName[key]
 		flagValue := flags[flagKey]
 		if flagValue == "" {
@@ -178,6 +179,7 @@ func parseResourceLabels(resourceKeyValues string, labels *map[string]string) er
 	return nil
 }
 
+// GetResponseCountMetricType constructs and returns a string representing the response_count metric type
 func (h *MetricHandler) GetResponseCountMetricType() string {
 	if h == nil {
 		return ""

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -127,10 +127,10 @@ func parseRequestIDs(response *http.Response, metricHandler *metrics.MetricHandl
 	}
 	responseBytes, err := ioutil.ReadAll(responseBody)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read the forwarded request: %q\n", err.Error())
+		return nil, fmt.Errorf("failed to read the forwarded request: %q", err.Error())
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Failed to list pending requests: %d, %q", response.StatusCode, responseBytes)
+		return nil, fmt.Errorf("failed to list pending requests: %d, %q", response.StatusCode, responseBytes)
 	}
 	if len(responseBytes) <= 0 {
 		return []string{}, nil
@@ -138,7 +138,7 @@ func parseRequestIDs(response *http.Response, metricHandler *metrics.MetricHandl
 
 	var requests []string
 	if err := json.Unmarshal(responseBytes, &requests); err != nil {
-		return nil, fmt.Errorf("Failed to parse the requests: %q\n", err.Error())
+		return nil, fmt.Errorf("failed to parse the requests: %q", err.Error())
 	}
 	return requests, nil
 }

--- a/agent/websockets/shim.go
+++ b/agent/websockets/shim.go
@@ -253,6 +253,7 @@ func (sb *shimmedBody) Close() error {
 	return sb.closer.Close()
 }
 
+// ShimBody returns a function that injects code into a *http.Response Body
 func ShimBody(shimPath string) (func(resp *http.Response) error, error) {
 	var templateBuf bytes.Buffer
 	if err := shimTmpl.Execute(&templateBuf, &struct{ ShimPath string }{ShimPath: shimPath}); err != nil {

--- a/testing/runlocal/main.go
+++ b/testing/runlocal/main.go
@@ -57,6 +57,7 @@ var (
 	respTmpl = template.Must(template.New("response").Parse(responseTemplate))
 )
 
+// RunLocalProxy runs a proxy locally
 func RunLocalProxy(ctx context.Context) (int, error) {
 	// This assumes that "Make build" has been run
 	proxyArgs := fmt.Sprintf("${GOPATH}/bin/inverting-proxy --port=%d", *port)


### PR DESCRIPTION
Resolves https://github.com/google/inverting-proxy/issues/2

## Errors Fixed
```sh
$ golint ./...
agent/agent.go:239:6: should omit values from range; this loop is equivalent to `for range ...`
agent/agent.go:261:6: should omit values from range; this loop is equivalent to `for range ...`
agent/banner/banner.go:143:3: struct field FavIconUrl should be FavIconURL
agent/banner/banner.go:188:9: if block ends with a return statement, so drop this else and outdent its block
agent/metrics/metrics.go:51:6: exported type MetricHandler should have comment or be unexported
agent/metrics/metrics.go:150:11: should omit 2nd value from range; this loop is equivalent to `for key := range ...`
agent/metrics/metrics.go:181:1: exported method MetricHandler.GetResponseCountMetricType should have comment or be unexported
agent/utils/utils.go:130:26: error strings should not be capitalized or end with punctuation or a newline
agent/utils/utils.go:141:26: error strings should not be capitalized or end with punctuation or a newline
agent/websockets/shim.go:256:1: exported function ShimBody should have comment or be unexported
testing/runlocal/main.go:60:1: exported function RunLocalProxy should have comment or be unexported
```