### PR TITLE
Display HTTP Requests if debug is enabled

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -134,6 +134,9 @@ func hostProxy(ctx context.Context, host, shimPath string, injectShimCode bool) 
 // the backend server and reports the response back to the proxy.
 func forwardRequest(client *http.Client, hostProxy http.Handler, request *utils.ForwardedRequest) error {
 	httpRequest := request.Contents
+	if *debug {
+		log.Printf("Request %s: %s %s %v\n", request.RequestID, request.Contents.Method, request.Contents.Host, request.Contents.ContentLength)
+	}
 	if *forwardUserID {
 		httpRequest.Header.Add(utils.HeaderUserID, request.User)
 	}


### PR DESCRIPTION
This new debug line will display HTTP requests that arrive from Proxy. Example: Saving a Notebook generates a PUT request and is relevant to be able to see it here.

Tested:
```
{"log":"2021/04/04 22:45:18 Request 005e38f07710c29e15d1e8943374ed969aab7d1d08fd708b39594ad6b309bbd90dc19fe3e0dbf0a7f10d103531f2a4f1dfaa
f8927447e05fe5bc62ad9d2b1d97e6c6e80fa0365cf5f91208811798b81643568815d0c0e265cc11a9ba15f9991211d4ce80210500b2f21dcd9ac79d29d910b5b5ddee9f
e758a2ecc5f632400a31: PUT 70efaed9f61f7d8f-dot-us-central1.notebooks.googleusercontent.com 30150937\n","stream":"stderr","time":"2021-04
-04T22:45:18.203076885Z"}
```