### PR TITLE
agent: ignore timeouts in list pending requests

### DIFF
--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -28,6 +28,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -225,6 +226,10 @@ func ListPendingRequests(client *http.Client, proxyHost, backendID string, metri
 	proxyReq.Header.Add(HeaderBackendID, backendID)
 	proxyResp, err := client.Do(proxyReq)
 	if err != nil {
+		if urlErr, ok := err.(*url.Error); ok && urlErr.Timeout() {
+			// The list pending either timed out or was cancelled; assume this means there are no pending requests.
+			return nil, nil
+		}
 		return nil, fmt.Errorf("A proxy request failed: %q", err.Error())
 	}
 	defer proxyResp.Body.Close()


### PR DESCRIPTION
When the agent tries to list pending requests and there are no requests to return, there are two possible behaviors:

1. The proxy stops waiting first and returns an empty list of request IDs.
2. The agent stops waiting first and returns a timeout error.

For both of these scenarios, the right next steps are the same; the proxy agent should just keep polling for pending requests.

However, previously these were handled differently; in the first case the agent would poll again immediately, whereas the second it would log an error message and then use backoff logic to decide how long to wait until polling again.

This *could* be handled by simply configuring the agent with a longer timeout than the proxy server, but since the proxy agent and server might not be run by the same administrator, it is better to make the agent handle this scenario gracefully.