### PR TITLE
Update the AppEngine version of the proxy to the latest Go runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 */#*#
 */.#*
+.gcloudignore

--- a/app/agent.yaml
+++ b/app/agent.yaml
@@ -14,10 +14,8 @@
 
 runtime: go116
 service: agent
-
+app_engine_apis: true
 handlers:
   - url: /agent/.*
     secure: always
-    script: _go_app
-
-
+    script: auto

--- a/app/api.yaml
+++ b/app/api.yaml
@@ -14,12 +14,12 @@
 
 runtime: go116
 service: api
-
+app_engine_apis: true
 handlers:
   - url: /api/.*
     secure: always
-    script: _go_app
+    script: auto
   - url: /cron/.*
     secure: always
     login: admin
-    script: _go_app
+    script: auto

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 runtime: go116
-
+app_engine_apis: true
 handlers:
   - url: /.*
     secure: always
     login: required
-    script: _go_app
+    script: auto

--- a/app/proxy/cache.go
+++ b/app/proxy/cache.go
@@ -17,12 +17,11 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
-
-	"google.golang.org/appengine/memcache"
+	"google.golang.org/appengine/v2/memcache"
 )
 
 const (

--- a/app/proxy/store.go
+++ b/app/proxy/store.go
@@ -17,15 +17,14 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
-	"google.golang.org/appengine/datastore"
-	"google.golang.org/appengine/log"
+	"google.golang.org/appengine/v2/datastore"
 )
 
 const (
@@ -112,7 +111,7 @@ func newBlob(ctx context.Context, bytes []byte, blobName string, t time.Time) (*
 
 	blobPartNames, err := writeBlobParts(ctx, bytes[fieldByteLimit:], blobName, t)
 	if err != nil {
-		log.Errorf(ctx, "Failed to write the parts of a blob: %q", err.Error())
+		log.Printf("Failed to write the parts of a blob: %q", err.Error())
 		return nil, err
 	}
 	b := &blob{
@@ -136,7 +135,7 @@ func (bp *blob) read(ctx context.Context) ([]byte, error) {
 	}
 
 	if err := datastore.GetMulti(ctx, keys, parts); err != nil {
-		log.Errorf(ctx, "Failed to read the parts of a blob: %q", err.Error())
+		log.Printf("Failed to read the parts of a blob: %q", err.Error())
 		return nil, err
 	}
 	for _, part := range parts {
@@ -293,7 +292,7 @@ func (d *persistentStore) ListPendingRequests(ctx context.Context, backendID str
 	go func() {
 		defer wg.Done()
 		if err := d.registerBackendAsSeen(ctx, backendID); err != nil {
-			log.Errorf(ctx, "Failed to register a backend [%q]: %q", backendID, err.Error())
+			log.Printf("Failed to register a backend [%q]: %q", backendID, err.Error())
 		}
 	}()
 	go func() {
@@ -324,7 +323,7 @@ func (d *persistentStore) WriteResponse(ctx context.Context, r *Response) error 
 		defer wg.Done()
 		backendID := r.BackendID
 		if err := d.registerBackendAsActive(ctx, backendID); err != nil {
-			log.Errorf(ctx, "Failed to update a backend's activity tracker [%q]: %q", backendID, err.Error())
+			log.Printf("Failed to update a backend's activity tracker [%q]: %q", backendID, err.Error())
 		}
 	}()
 	go func() {

--- a/app/proxy/types.go
+++ b/app/proxy/types.go
@@ -17,9 +17,8 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // Request represents an end-user request that we forward.

--- a/go.mod
+++ b/go.mod
@@ -11,18 +11,19 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/googleapis/gax-go/v2 v2.3.0
 	github.com/gorilla/websocket v1.5.0
-	golang.org/x/net v0.0.0-20220420153159-1850ba15e1be
+	golang.org/x/net v0.0.0-20220708220712-1185a9018129
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	google.golang.org/api v0.75.0
-	google.golang.org/appengine v1.6.7
+	google.golang.org/appengine/v2 v2.0.2
 	google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3
 )
 
 require (
 	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.45.0 // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220420153159-1850ba15e1be h1:yx80W7nvY5ySWpaU8UWaj5o9e23YgO9BRhQol7Lc+JI=
-golang.org/x/net v0.0.0-20220420153159-1850ba15e1be/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -368,8 +368,9 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -487,6 +488,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine/v2 v2.0.2 h1:MSqyWy2shDLwG7chbwBJ5uMyw6SNqJzhJHNDwYB0Akk=
+google.golang.org/appengine/v2 v2.0.2/go.mod h1:PkgRUWz4o1XOvbqtWTkBtCitEJ5Tp4HoVEdMMYQR/8E=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -602,8 +605,9 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=


### PR DESCRIPTION
The old `go1` runtime that was previously used is no longer supported, and so the AppEngine version of the proxy was no longer usable.

A previous change tried to fix that by upgrading to the latest `go116` version, but simply upgrading was not sufficient as the new runtime is not backwards compatible to the older runtime.

This change finishes the migration to `go116`, which required restructuring the app. I followed the guide [here](https://cloud.google.com/appengine/docs/standard/go/go-differences) to do that restructuring.

Additionally, I've removed the usage of the legacy AppEngine logging package, and switched the usages of `context` over to the version in the standard library.