### PR TITLE
Fix formatting in golang files that were misformatted

### DIFF
--- a/agent/sessions/sessions.go
+++ b/agent/sessions/sessions.go
@@ -31,6 +31,7 @@ limitations under the License.
 // app that integrates the proxy with the backend server(s).
 //
 // Example usage:
+//
 //	wrappedHandler := ...
 //	...
 //	sessionCookieName := "proxy-session-cookie-name"

--- a/agent/utils/utils_test.go
+++ b/agent/utils/utils_test.go
@@ -178,45 +178,45 @@ func TestReadRequestWithRetries(t *testing.T) {
 }
 
 func TestBufferedReadSeeker(t *testing.T) {
-        r := bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
-        brs := newBufferedReadSeeker(r, 5)
-        p1 := make([]byte, 4)
-        p2 := make([]byte, 6)
-        wantN := 2
-        wantO := int64(0)
+	r := bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	brs := newBufferedReadSeeker(r, 5)
+	p1 := make([]byte, 4)
+	p2 := make([]byte, 6)
+	wantN := 2
+	wantO := int64(0)
 
-        // Pass 1: read 2 + 2 = 4 bytes, which is less than buffer size.
-        if gotN, gotErr := brs.Read(p1[0:2]); gotN != wantN || gotErr != nil {
-                t.Errorf("Read(pass 1 part 1): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
-        }
-        if gotN, gotErr := brs.Read(p1[2:4]); gotN != wantN || gotErr != nil {
-                t.Errorf("Read(pass 1 part 2): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
-        }
-        // Reset offset to 0: succeeds because the buffer has not been filled up.
-        if gotO, gotErr := brs.Seek(0, io.SeekStart); gotO != wantO || gotErr != nil {
-                t.Errorf("Seek(buffer not filled up): got %v, %v; want %v, %v", gotO, gotErr, wantO, nil)
-        }
-        // Pass 2: read 2 + 2 + 2 = 6 bytes, which exceeds buffer size.
-        if gotN, gotErr := brs.Read(p2[0:2]); gotN != wantN || gotErr != nil {
-                t.Errorf("Read(pass 2 part 1): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
-        }
-        if gotN, gotErr := brs.Read(p2[2:4]); gotN != wantN || gotErr != nil {
-                t.Errorf("Read(pass 2 part 2): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
-        }
-        if gotN, gotErr := brs.Read(p2[4:6]); gotN != wantN || gotErr != nil {
-                t.Errorf("Read(pass 2 part 3): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
-        }
-        // Reset offset to 0: fails because the buffer has been filled up.
-        if gotO, gotErr := brs.Seek(0, io.SeekStart); gotErr == nil {
-                t.Errorf("Seek(buffer filled up): got %v, %v; want error", gotO, gotErr)
-        }
+	// Pass 1: read 2 + 2 = 4 bytes, which is less than buffer size.
+	if gotN, gotErr := brs.Read(p1[0:2]); gotN != wantN || gotErr != nil {
+		t.Errorf("Read(pass 1 part 1): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
+	}
+	if gotN, gotErr := brs.Read(p1[2:4]); gotN != wantN || gotErr != nil {
+		t.Errorf("Read(pass 1 part 2): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
+	}
+	// Reset offset to 0: succeeds because the buffer has not been filled up.
+	if gotO, gotErr := brs.Seek(0, io.SeekStart); gotO != wantO || gotErr != nil {
+		t.Errorf("Seek(buffer not filled up): got %v, %v; want %v, %v", gotO, gotErr, wantO, nil)
+	}
+	// Pass 2: read 2 + 2 + 2 = 6 bytes, which exceeds buffer size.
+	if gotN, gotErr := brs.Read(p2[0:2]); gotN != wantN || gotErr != nil {
+		t.Errorf("Read(pass 2 part 1): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
+	}
+	if gotN, gotErr := brs.Read(p2[2:4]); gotN != wantN || gotErr != nil {
+		t.Errorf("Read(pass 2 part 2): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
+	}
+	if gotN, gotErr := brs.Read(p2[4:6]); gotN != wantN || gotErr != nil {
+		t.Errorf("Read(pass 2 part 3): got %v, %v; want %v, %v", gotN, gotErr, wantN, nil)
+	}
+	// Reset offset to 0: fails because the buffer has been filled up.
+	if gotO, gotErr := brs.Seek(0, io.SeekStart); gotErr == nil {
+		t.Errorf("Seek(buffer filled up): got %v, %v; want error", gotO, gotErr)
+	}
 
-        if got, want := p1, []byte{1, 2, 3, 4}; !bytes.Equal(got, want) {
-                t.Errorf("Unexpected values read in pass 1: got %v, want %v", got, want)
-        }
-        if got, want := p2, []byte{1, 2, 3, 4, 5, 6}; !bytes.Equal(got, want) {
-                t.Errorf("Unexpected values read in pass 2: got %v, want %v", got, want)
-        }
+	if got, want := p1, []byte{1, 2, 3, 4}; !bytes.Equal(got, want) {
+		t.Errorf("Unexpected values read in pass 1: got %v, want %v", got, want)
+	}
+	if got, want := p2, []byte{1, 2, 3, 4, 5, 6}; !bytes.Equal(got, want) {
+		t.Errorf("Unexpected values read in pass 2: got %v, want %v", got, want)
+	}
 }
 
 func TestResponseForwarder(t *testing.T) {

--- a/app/proxy.go
+++ b/app/proxy.go
@@ -18,7 +18,7 @@ limitations under the License.
 //
 // To deploy, export the ID of your project as ${PROJECT_ID} and then run:
 //
-//    $ make deploy
+//	$ make deploy
 package main
 
 import (

--- a/server/server.go
+++ b/server/server.go
@@ -17,8 +17,9 @@ limitations under the License.
 // Command server launches a stand-alone inverting proxy.
 //
 // Example usage:
-//   go build -o ~/bin/inverting-proxy ./server/server.go
-//   ~/bin/inverting-proxy --port 8081
+//
+//	go build -o ~/bin/inverting-proxy ./server/server.go
+//	~/bin/inverting-proxy --port 8081
 package main
 
 import (

--- a/testing/runlocal/main.go
+++ b/testing/runlocal/main.go
@@ -18,8 +18,9 @@ limitations under the License.
 // locally test changes to the code in the agent or server packages
 //
 // Example usage:
-//   go build -o ~/bin/inverting-proxy-run-local testing/runlocal/main.go
-//   ~/bin/inverting-proxy-run-local --port 8081
+//
+//	go build -o ~/bin/inverting-proxy-run-local testing/runlocal/main.go
+//	~/bin/inverting-proxy-run-local --port 8081
 package main
 
 import (

--- a/testing/websockets/example/main.go
+++ b/testing/websockets/example/main.go
@@ -19,8 +19,9 @@ limitations under the License.
 // implementation of websockets provided by the inverting proxy and agent.
 //
 // Example usage:
-//   go build -o ~/bin/example-websocket-sever testing/websockets/example/main.go
-//   ~/bin/example-websocket-server --port 8082
+//
+//	go build -o ~/bin/example-websocket-sever testing/websockets/example/main.go
+//	~/bin/example-websocket-server --port 8082
 package main
 
 import (

--- a/testing/websockets/main.go
+++ b/testing/websockets/main.go
@@ -18,8 +18,9 @@ limitations under the License.
 // manually test changes to the code in the agent/websockets package
 //
 // Example usage:
-//   go build -o ~/bin/test-websocket-server testing/websockets/main.go
-//   ~/bin/test-websocket-server --port 8081 --backend http://localhost:8082
+//
+//	go build -o ~/bin/test-websocket-server testing/websockets/main.go
+//	~/bin/test-websocket-server --port 8081 --backend http://localhost:8082
 package main
 
 import (


### PR DESCRIPTION
The included changes were generated by running the `make test` command in the root directory, which in turn runs `gofmt -w`