### PR TITLE
Support the HTTP/2 proto for response forwarding.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -144,7 +144,7 @@ func forwardRequest(client *http.Client, hostProxy http.Handler, request *utils.
 	if *stripCredentials {
 		httpRequest.Header.Del(headerAuthorization)
 	}
-	responseForwarder, err := utils.NewResponseForwarder(client, *proxy, request.BackendID, request.RequestID)
+	responseForwarder, err := utils.NewResponseForwarder(client, *proxy, request.BackendID, request.RequestID, request.Contents)
 	if err != nil {
 		return fmt.Errorf("failed to create the response forwarder: %v", err)
 	}

--- a/agent/utils/utils.go
+++ b/agent/utils/utils.go
@@ -429,7 +429,7 @@ func postResponseWithRetries(client *http.Client, proxyURL, backendID, requestID
 
 // NewResponseForwarder constructs a new ResponseForwarder that forwards to the
 // given proxy for the specified request.
-func NewResponseForwarder(client *http.Client, proxyHost, backendID, requestID string) (*ResponseForwarder, error) {
+func NewResponseForwarder(client *http.Client, proxyHost, backendID, requestID string, r *http.Request) (*ResponseForwarder, error) {
 	// The contortions below support streaming.
 	//
 	// There are two pipes:
@@ -467,11 +467,19 @@ func NewResponseForwarder(client *http.Client, proxyHost, backendID, requestID s
 		close(proxyClientErrChan)
 	}()
 
+	proto := "HTTP/1.1"
+	protoMajor := 1
+	protoMinor := 1
+	if r != nil {
+		proto = r.Proto
+		protoMajor = r.ProtoMajor
+		protoMinor = r.ProtoMinor
+	}
 	return &ResponseForwarder{
 		response: &http.Response{
-			Proto:      "HTTP/1.1",
-			ProtoMajor: 1,
-			ProtoMinor: 1,
+			Proto:      proto,
+			ProtoMajor: protoMajor,
+			ProtoMinor: protoMinor,
 			Header:     make(http.Header),
 			Body:       responseBodyReader,
 		},


### PR DESCRIPTION
Previously, the HTTP response forwarded by the proxy agent to the
proxy had a hard-coded proto of "HTTP/1.1".

With this change, it will instead use a proto that matches the
request received by the agent from the proxy.