### PR TITLE
Support forwarding HTTP requests from IVP to a sidecar HTTP backend.

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -53,5 +53,7 @@ ENV REWRITE_WEBSOCKET_HOST "false"
 ENV MONITORING_PROJECT_ID ""
 ENV MONITORING_RESOURCE_LABELS ""
 ENV METRIC_DOMAIN ""
+ENV SIDECAR_HOST ""
+ENV SIDECAR_URL_PATH ""
 
-CMD ["/bin/sh", "-c", "/opt/bin/proxy-forwarding-agent --debug=${DEBUG} --proxy=${PROXY} --proxy-timeout=${PROXY_TIMEOUT} --backend=${BACKEND} --host=${HOSTNAME}:${PORT} --shim-websockets=${SHIM_WEBSOCKETS} --shim-path=${SHIM_PATH} --health-check-path=${HEALTH_CHECK_PATH} --health-check-interval-seconds=${HEALTH_CHECK_INTERVAL_SECONDS} --health-check-unhealthy-threshold=${HEALTH_CHECK_UNHEALTHY_THRESHOLD} --session-cookie-name=${SESSION_COOKIE_NAME} --forward-user-id=${FORWARD_USER_ID} --rewrite-websocket-host=${REWRITE_WEBSOCKET_HOST} --monitoring-project-id=${MONITORING_PROJECT_ID} --monitoring-resource-labels=${MONITORING_RESOURCE_LABELS} --metric-domain=${METRIC_DOMAIN}"]
+CMD ["/bin/sh", "-c", "/opt/bin/proxy-forwarding-agent --debug=${DEBUG} --proxy=${PROXY} --proxy-timeout=${PROXY_TIMEOUT} --backend=${BACKEND} --host=${HOSTNAME}:${PORT} --shim-websockets=${SHIM_WEBSOCKETS} --shim-path=${SHIM_PATH} --health-check-path=${HEALTH_CHECK_PATH} --health-check-interval-seconds=${HEALTH_CHECK_INTERVAL_SECONDS} --health-check-unhealthy-threshold=${HEALTH_CHECK_UNHEALTHY_THRESHOLD} --session-cookie-name=${SESSION_COOKIE_NAME} --forward-user-id=${FORWARD_USER_ID} --rewrite-websocket-host=${REWRITE_WEBSOCKET_HOST} --monitoring-project-id=${MONITORING_PROJECT_ID} --monitoring-resource-labels=${MONITORING_RESOURCE_LABELS} --metric-domain=${METRIC_DOMAIN} --sidecar-host=${SIDECAR_HOST} --sidecar-url-path=${SIDECAR_URL_PATH}}"]

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -49,8 +49,9 @@ import (
 )
 
 const (
-	backendCookie = "backend-cookie"
-	sessionCookie = "proxy-sessions-cookie"
+	backendCookie  = "backend-cookie"
+	sessionCookie  = "proxy-sessions-cookie"
+	sidecarURLPath = "/custom/hello"
 )
 
 func checkRequest(proxyURL, testPath, want string, timeout time.Duration, expectedCookie string) error {
@@ -173,6 +174,35 @@ func RunGRPCBackend(ctx context.Context, t *testing.T) (string, error) {
 		lis.Close()
 	}()
 	return lis.Addr().String(), nil
+}
+
+func RunSidecarBackend(ctx context.Context, t *testing.T) string {
+	backendCookieVal := uuid.New().String()
+	mux := http.NewServeMux()
+	mux.HandleFunc(sidecarURLPath, func(w http.ResponseWriter, r *http.Request) {
+		bc, err := r.Cookie(backendCookie)
+		if err == http.ErrNoCookie || bc == nil {
+			bc = &http.Cookie{
+				Name:     backendCookie,
+				Value:    backendCookieVal,
+				HttpOnly: true,
+			}
+			http.SetCookie(w, bc)
+			http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)
+			return
+		}
+		if got, want := bc.Value, backendCookieVal; got != want {
+			t.Errorf("Unexepected backend cookie value: got %q, want %q", got, want)
+		}
+		fmt.Fprint(w, "Hello, World!")
+	})
+
+	backendServer := httptest.NewServer(mux)
+	go func() {
+		<-ctx.Done()
+		backendServer.Close()
+	}()
+	return backendServer.URL
 }
 
 func RunFakeMetadataServer(ctx context.Context, t *testing.T) string {
@@ -350,6 +380,97 @@ func TestWithInMemoryProxyAndBackendWithSessions(t *testing.T) {
 		// The specific value was chosen by running the test in a loop 100 times and
 		// incrementing the value until all 100 runs passed.
 		if err := checkRequest(proxyURL, testPath, testPath, 100*time.Millisecond, sessionCookie); err != nil {
+			t.Fatalf("Failed to send request %d: %v", i, err)
+		}
+	}
+}
+
+func TestWithInMemoryProxyAndSidecarBackend(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backendHomeDir, err := ioutil.TempDir("", "backend-home")
+	if err != nil {
+		t.Fatalf("Failed to set up a temporary home directory for the test: %v", err)
+	}
+	gcloudCfg := filepath.Join(backendHomeDir, ".config", "gcloud")
+	if err := os.MkdirAll(gcloudCfg, os.ModePerm); err != nil {
+		t.Fatalf("Failed to set up a temporary home directory for the test: %v", err)
+	}
+	backendURL := RunBackend(ctx, t)
+	sidecarURL := RunSidecarBackend(ctx, t)
+	fakeMetadataURL := RunFakeMetadataServer(ctx, t)
+
+	parsedBackendURL, err := url.Parse(backendURL)
+	if err != nil {
+		t.Fatalf("Failed to parse the backend URL: %v", err)
+	}
+	parsedSidecarURL, err := url.Parse(sidecarURL)
+	if err != nil {
+		t.Fatalf("Failed to parse the sidecar URL: %v", err)
+	}
+	proxyPort, err := RunLocalProxy(ctx, t)
+	proxyURL := fmt.Sprintf("http://localhost:%d", proxyPort)
+	if err != nil {
+		t.Fatalf("Failed to run the local inverting proxy: %v", err)
+	}
+	t.Logf("Started backend at localhost:%s and proxy at %s", parsedBackendURL.Port(), proxyURL)
+
+	// This assumes that "Make build" has been run
+	args := strings.Join(append(
+		[]string{"/${GOPATH}/bin/proxy-forwarding-agent"},
+		"--debug=true",
+		"--backend=testBackend",
+		"--proxy", proxyURL+"/",
+		"--sidecar-url-path="+sidecarURLPath,
+		"--sidecar-host=localhost:"+parsedSidecarURL.Port(),
+		"--host=localhost:"+parsedBackendURL.Port()),
+		" ")
+	agentCmd := exec.CommandContext(ctx, "/bin/bash", "-c", args)
+
+	var out bytes.Buffer
+	agentCmd.Stdout = &out
+	agentCmd.Stderr = &out
+	agentCmd.Env = append(os.Environ(), "PATH=", "HOME="+backendHomeDir, "GCE_METADATA_HOST="+strings.TrimPrefix(fakeMetadataURL, "http://"))
+	if err := agentCmd.Start(); err != nil {
+		t.Fatalf("Failed to start the agent binary: %v", err)
+	}
+	defer func() {
+		cancel()
+		err := agentCmd.Wait()
+		t.Logf("Agent result: %v, stdout/stderr: %q", err, out.String())
+	}()
+
+	// Send one request through the proxy to make sure the agent has come up.
+	//
+	// We give this initial request a long time to complete, as the agent takes
+	// a long time to start up.
+	testPath := "/some/request/path"
+	if err := checkRequest(proxyURL, testPath, testPath, time.Second, backendCookie); err != nil {
+		t.Fatalf("Failed to send the initial request: %v", err)
+	}
+	if err := checkRequest(proxyURL, sidecarURLPath, "Hello, World!", time.Second, backendCookie); err != nil {
+		t.Fatalf("Failed to send the initial request for sidecar host: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		// The timeout below was chosen to be overly generous to prevent test flakiness.
+		//
+		// This has the consequence that it will only catch severe latency regressions.
+		//
+		// The specific value was chosen by running the test in a loop 100 times and
+		// incrementing the value until all 100 runs passed.
+		if err := checkRequest(proxyURL, testPath, testPath, 100*time.Millisecond, backendCookie); err != nil {
+			t.Fatalf("Failed to send request %d: %v", i, err)
+		}
+	}
+	for i := 0; i < 10; i++ {
+		// The timeout below was chosen to be overly generous to prevent test flakiness.
+		//
+		// This has the consequence that it will only catch severe latency regressions.
+		//
+		// The specific value was chosen by running the test in a loop 100 times and
+		// incrementing the value until all 100 runs passed.
+		if err := checkRequest(proxyURL, sidecarURLPath, "Hello, World!", 100*time.Millisecond, backendCookie); err != nil {
 			t.Fatalf("Failed to send request %d: %v", i, err)
 		}
 	}


### PR DESCRIPTION
Why? For certain backends is important to route some paths to sidecar agents such as a Health agent that can report status and stats of backend and additional components. This allow opening a communication channel between front end and other web servers running in same VM as agent. A Health agent or sidecar app may need to receive notifications from FE without using default backend URL. Example: endpoint-<region>-<product>.googleusercontent.com/vertex/health can provide information for all services in VM assuming there is a agent running in same BE or FE can send commands to alternate BE. This prevents having to run an additional Proxy Agent and registering 2 endpoints in same VM.