### PR TITLE
Deleting closed connections from the connections map

### DIFF
--- a/agent/websockets/shim.go
+++ b/agent/websockets/shim.go
@@ -488,6 +488,7 @@ func createShimChannel(ctx context.Context, host, shimPath string, rewriteHost b
 			statusCode := http.StatusBadRequest
 			http.Error(w, fmt.Sprintf("attempt to read data from a closed session: %q", msg.ID), statusCode)
 			metricHandler.WriteResponseCodeMetric(statusCode)
+			connections.Delete(msg.ID)
 			return
 		} else if serverMsgs == nil {
 			statusCode := http.StatusRequestTimeout


### PR DESCRIPTION
After extensive testing we found that the connections map hosting correct setup of connections:
 $ docker logs  ba-proxy-agent 2>&1 | grep "attempt to read data from a closed session" | wc
   2479   27269  174902
 $ docker logs -f ba-proxy-agent --tail 10
2024/09/26 10:57:28 Websocket connection to the server "ws://localhost:8094/websocket-shim/" established for session: 3141
, total sessions: 662
2024/09/26 10:57:28 Websocket connection to the server "ws://localhost:8094/websocket-shim/" established for session: 3143
, total sessions: 663
2024/09/26 10:57:28 Websocket connection to the server "ws://localhost:8094/websocket-shim/" established for session: 3142
, total sessions: 664
2024/09/26 10:57:28 Websocket connection to the server "ws://localhost:8094/websocket-shim/" established for session: 3144
, total sessions: 665
2024/09/26 10:57:28 Websocket connection to the server "ws://localhost:8094/websocket-shim/" established for session: 3145
, total sessions: 666