### PR TITLE
[agent] Cleanup unused, shimmed websocket connections after a configurable timeout.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -73,6 +73,7 @@ var (
 	injectBanner              = flag.String("inject-banner", "", "HTML snippet to inject in served webpages")
 	bannerHeight              = flag.String("banner-height", "40px", "Height of the injected banner. This is ignored if no banner is set.")
 	shimWebsockets            = flag.Bool("shim-websockets", false, "Whether or not to replace websockets with a shim")
+	websocketShimTimeout      = flag.Duration("websocket-shim-timeout", 60*time.Minute, "Timeout for websocket shim connections to expire due to inactivity.")
 	shimPath                  = flag.String("shim-path", "", "Path under which to handle websocket shim requests")
 	healthCheckPath           = flag.String("health-check-path", "/", "Path on backend host to issue health checks against.  Defaults to the root.")
 	healthCheckFreq           = flag.Int("health-check-interval-seconds", 0, "Wait time in seconds between health checks.  Set to zero to disable health checks.  Checks disabled by default.")
@@ -126,7 +127,8 @@ func hostProxy(ctx context.Context, host, shimPath string, injectShimCode, force
 		// restricted to a path prefix not equal to "/" will fail for websocket open requests. Passing in the
 		// sessionHandler twice allows the websocket handler to ensure that cookies are applied based on the
 		// correct, restored path.
-		h, err = websockets.Proxy(ctx, h, host, shimPath, *rewriteWebsocketHost, *enableWebsocketsInjection, sessionLRU.SessionHandler, metricHandler)
+		h, err = websockets.Proxy(ctx, h, host, shimPath, *rewriteWebsocketHost, *enableWebsocketsInjection, sessionLRU.SessionHandler,
+			metricHandler, *websocketShimTimeout)
 		if injectShimCode {
 			shimFunc, err := websockets.ShimBody(shimPath)
 			if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -220,7 +220,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.Lock()
 	p.requests[id] = pending
 	p.Unlock()
-	defer func(){
+	defer func() {
 		p.Lock()
 		delete(p.requests, id)
 		p.Unlock()


### PR DESCRIPTION
This PR adds a configurable value for how long shimmed websocket connections can remain idle before they are garbage collected.

Previously, the underlying connection from the proxy agent to the backend server was only cleaned up when there was either an error while sending or receiving messages, or if the agent received an explicit close message.

When a client of shim protocol stopped communicating without first sending a close message, this caused the underlying connection between the proxy agent and backend server to be retained indefinitely. That, in turn, can result in a resource leak within the agent (and possibly in the backend server as well).

To account for that scenario, we needed to find some way to identify that a client of the shim protocol had stopped communicating, so that we could clean up those lost connections.

The shim protocol does not include any sort of ping or pong messages, but it does have polling requests sent by the client which can be used as a dead-man switch; once a sufficient amount of time has elapsed since the last such request, we can assume that the client is gone and the underlying connection can be removed.

This PR adds a configuration option to the agent to specify what that amount of time should be (with a default of 1 hour), and implements the agent-side cleanup logic to identify and close expired connections.